### PR TITLE
Added the changes to set job status in-memory struct.

### DIFF
--- a/common/fe-ste-models.go
+++ b/common/fe-ste-models.go
@@ -641,6 +641,9 @@ func (TransferStatus) Success() TransferStatus { return TransferStatus(2) }
 // Folder was created, but properties have not been persisted yet. Equivalent to Started, but never intended to be set on anything BUT folders.
 func (TransferStatus) FolderCreated() TransferStatus { return TransferStatus(3) }
 
+// Job complete, This is used to tell jobStatus Manager about job complete.
+func (TransferStatus) JobComplete() TransferStatus { return TransferStatus(4) }
+
 // Transfer failed due to some error.
 func (TransferStatus) Failed() TransferStatus { return TransferStatus(-1) }
 

--- a/common/rpc-models.go
+++ b/common/rpc-models.go
@@ -309,6 +309,7 @@ type TransferDetail struct {
 	TransferSize       uint64
 	ErrorCode          int32  `json:",string"`
 	ErrorMessage       string `json:",string"`
+	JobStatus          uint32 `json:",string"`
 }
 
 type CancelPauseResumeResponse struct {

--- a/jobsAdmin/init.go
+++ b/jobsAdmin/init.go
@@ -24,11 +24,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/nitin-deamon/azure-storage-azcopy/v10/ste"
 	"io/ioutil"
 	"math"
 	"net/http"
 	"time"
+
+	"github.com/nitin-deamon/azure-storage-azcopy/v10/ste"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 
@@ -36,7 +37,6 @@ import (
 )
 
 var steCtx = context.Background()
-
 
 const EMPTY_SAS_STRING = ""
 
@@ -123,19 +123,19 @@ func MainSTE(concurrency ste.ConcurrencySettings, targetRateInMegaBitsPerSec flo
 			serialize(ListJobTransfers(payload), writer) // TODO: make struct
 		})
 	/*
-	http.HandleFunc(common.ERpcCmd.CancelJob().Pattern(),
-		func(writer http.ResponseWriter, request *http.Request) {
-			var payload common.JobID
-			deserialize(request, &payload)
-			serialize(CancelPauseJobOrder(payload, common.EJobStatus.Cancelling()), writer)
-		})
-	http.HandleFunc(common.ERpcCmd.PauseJob().Pattern(),
-		func(writer http.ResponseWriter, request *http.Request) {
-			var payload common.JobID
-			deserialize(request, &payload)
-			serialize(CancelPauseJobOrder(payload, common.EJobStatus.Paused()), writer)
-		})
-	 */
+		http.HandleFunc(common.ERpcCmd.CancelJob().Pattern(),
+			func(writer http.ResponseWriter, request *http.Request) {
+				var payload common.JobID
+				deserialize(request, &payload)
+				serialize(CancelPauseJobOrder(payload, common.EJobStatus.Cancelling()), writer)
+			})
+		http.HandleFunc(common.ERpcCmd.PauseJob().Pattern(),
+			func(writer http.ResponseWriter, request *http.Request) {
+				var payload common.JobID
+				deserialize(request, &payload)
+				serialize(CancelPauseJobOrder(payload, common.EJobStatus.Paused()), writer)
+			})
+	*/
 	http.HandleFunc(common.ERpcCmd.ResumeJob().Pattern(),
 		func(writer http.ResponseWriter, request *http.Request) {
 			var payload common.ResumeJobRequest
@@ -215,6 +215,7 @@ func CancelPauseJobOrder(jobID common.JobID, desiredJobStatus common.JobStatus) 
 	}
 	return jm.CancelPauseJobOrder(desiredJobStatus)
 }
+
 /*
 	// Search for the Part 0 of the Job, since the Part 0 status concludes the actual status of the Job
 	jpm, found := jm.JobPartMgr(0)
@@ -362,7 +363,7 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 	// Cancelling is an intermediary state. The reason we accept and process it here, rather than returning an error,
 	// is in case a process was terminated while its job was in cancelling state.
 	case common.EJobStatus.Cancelling():
-		jpp0.SetJobStatus(common.EJobStatus.Cancelled())
+		jm.SetJobStatus(common.EJobStatus.Cancelled())
 		fallthrough
 
 	// Resume all the failed / In Progress Transfers.
@@ -382,7 +383,7 @@ func ResumeJobOrder(req common.ResumeJobRequest) common.CancelPauseResumeRespons
 				CredentialInfo: req.CredentialInfo,
 			})
 
-		jpp0.SetJobStatus(common.EJobStatus.InProgress())
+		jm.SetJobStatus(common.EJobStatus.InProgress())
 
 		// Jank, force the jstm to recognize that it's also in progress
 		summaryResp := jm.ListJobSummary()
@@ -496,17 +497,18 @@ func GetJobSummary(jobID common.JobID) common.ListJobSummaryResponse {
 	dir := jm.TransferDirection()
 	p := jm.PipelineNetworkStats()
 	if part0PlanStatus == common.EJobStatus.Cancelled() {
-		js.JobStatus = part0PlanStatus
+		// commenting out setting of JobStatus from plan file.
+		//	js.JobStatus = part0PlanStatus
 		js.PerformanceAdvice = JobsAdmin.TryGetPerformanceAdvice(js.TotalBytesExpected, js.TotalTransfers-js.TransfersSkipped, part0.Plan().FromTo, dir, p)
 	} else {
 		// Job is completed if Job order is complete AND ALL transfers are completed/failed
 		// FIX: active or inactive state, then job order is said to be completed if final part of job has been ordered.
-		if (js.CompleteJobOrdered) && (part0PlanStatus.IsJobDone()) {
+		/* if (js.CompleteJobOrdered) && (part0PlanStatus.IsJobDone()) {
 			js.JobStatus = part0PlanStatus
-		}
+		} */
 
 		if js.JobStatus.IsJobDone() {
-			js.PerformanceAdvice = JobsAdmin.TryGetPerformanceAdvice(js.TotalBytesExpected, js.TotalTransfers-js.TransfersSkipped, part0.Plan().FromTo, dir, p )
+			js.PerformanceAdvice = JobsAdmin.TryGetPerformanceAdvice(js.TotalBytesExpected, js.TotalTransfers-js.TransfersSkipped, part0.Plan().FromTo, dir, p)
 		}
 	}
 

--- a/ste/mgr-JobPartMgr.go
+++ b/ste/mgr-JobPartMgr.go
@@ -14,14 +14,15 @@ import (
 	"time"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
-	"github.com/nitin-deamon/azure-storage-azcopy/v10/azbfs"
-	"github.com/nitin-deamon/azure-storage-azcopy/v10/common"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/azure-storage-file-go/azfile"
+	"github.com/nitin-deamon/azure-storage-azcopy/v10/azbfs"
+	"github.com/nitin-deamon/azure-storage-azcopy/v10/common"
 	"golang.org/x/sync/semaphore"
 )
 
 var _ IJobPartMgr = &jobPartMgr{}
+
 // debug knob
 var DebugSkipFiles = make(map[string]bool)
 
@@ -332,7 +333,7 @@ func (jpm *jobPartMgr) ScheduleTransfers(jobCtx context.Context) {
 	plan := jpm.planMMF.Plan()
 	if plan.PartNum == 0 && plan.NumTransfers == 0 {
 		/* This will wind down the transfer and report summary */
-		plan.SetJobStatus(common.EJobStatus.Completed())
+		jpm.jobMgr.SetJobStatus(common.EJobStatus.Completed())
 		return
 	}
 


### PR DESCRIPTION
- Added new job status field in jobStatusMgr.
- And this is used to get status of job instead of plan file.

Note:
- We have 2 options at this point.
a) Either we make jobstatusMgr xferchannel to be sync one.(But it has
perf issue where every file transfer wait for statusHandler go routine
to process the message. It will be include too many context switches.
b) Let get the job Status from jobstatusMgr only, it hasn't perf issue
as it will not impact overall performance of transfers, but we get job
completion status few secs later.