### PR TITLE
[Draft] enumerate source and target using the streaming algorithm

### DIFF
--- a/cmd/copyEnumeratorInit.go
+++ b/cmd/copyEnumeratorInit.go
@@ -71,7 +71,7 @@ func (cca *CookedCopyCmdArgs) initEnumerator(jobPartOrder common.CopyJobPartOrde
 	traverser, err = InitResourceTraverser(cca.Source, cca.FromTo.From(), &ctx, &srcCredInfo,
 		&cca.FollowSymlinks, cca.ListOfFilesChannel, cca.Recursive, getRemoteProperties,
 		cca.IncludeDirectoryStubs, func(common.EntityType) {}, cca.ListOfVersionIDs,
-		cca.S2sPreserveBlobTags, cca.LogVerbosity.ToPipelineLogLevel(), cca.CpkOptions, nil /* errorChannel */)
+		cca.S2sPreserveBlobTags, cca.LogVerbosity.ToPipelineLogLevel(), cca.CpkOptions, nil /* errorChannel */, false, nil)
 
 	if err != nil {
 		return nil, err
@@ -337,7 +337,7 @@ func (cca *CookedCopyCmdArgs) isDestDirectory(dst common.ResourceString, ctx *co
 
 	rt, err := InitResourceTraverser(dst, cca.FromTo.To(), ctx, &dstCredInfo, nil,
 		nil, false, false, false,
-		func(common.EntityType) {}, cca.ListOfVersionIDs, false, pipeline.LogNone, cca.CpkOptions, nil /* errorChannel */)
+		func(common.EntityType) {}, cca.ListOfVersionIDs, false, pipeline.LogNone, cca.CpkOptions, nil /* errorChannel */, false, nil)
 
 	if err != nil {
 		return false

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -221,7 +221,7 @@ func (cooked cookedListCmdArgs) HandleListContainerCommand() (err error) {
 
 	traverser, err := InitResourceTraverser(source, cooked.location, &ctx, &credentialInfo, nil, nil,
 		true, false, false, func(common.EntityType) {},
-		nil, false, pipeline2.LogNone, common.CpkOptions{}, nil /* errorChannel */)
+		nil, false, pipeline2.LogNone, common.CpkOptions{}, nil /* errorChannel */, false, nil)
 
 	if err != nil {
 		return fmt.Errorf("failed to initialize traverser: %s", err.Error())

--- a/cmd/removeEnumerator.go
+++ b/cmd/removeEnumerator.go
@@ -51,7 +51,7 @@ func newRemoveEnumerator(cca *CookedCopyCmdArgs) (enumerator *CopyEnumerator, er
 	sourceTraverser, err = InitResourceTraverser(cca.Source, cca.FromTo.From(), &ctx, &cca.credentialInfo,
 		nil, cca.ListOfFilesChannel, cca.Recursive, false, cca.IncludeDirectoryStubs,
 		func(common.EntityType) {}, cca.ListOfVersionIDs, false,
-		cca.LogVerbosity.ToPipelineLogLevel(), cca.CpkOptions, nil /* errorChannel */)
+		cca.LogVerbosity.ToPipelineLogLevel(), cca.CpkOptions, nil /* errorChannel */, false, nil)
 
 	// report failure to create traverser
 	if err != nil {

--- a/cmd/syncEnumerator.go
+++ b/cmd/syncEnumerator.go
@@ -54,7 +54,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 			}
 		}
 	}
-
+	queueUnstartedDirs := make(chan interface{}, 1000)
 	// TODO: enable symlink support in a future release after evaluating the implications
 	// TODO: Consider passing an errorChannel so that enumeration errors during sync can be conveyed to the caller.
 	// GetProperties is enabled by default as sync supports both upload and download.
@@ -64,7 +64,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 			if entityType == common.EEntityType.File() {
 				atomic.AddUint64(&cca.atomicSourceFilesScanned, 1)
 			}
-		}, nil, cca.s2sPreserveBlobTags, cca.logVerbosity.ToPipelineLogLevel(), cca.cpkOptions, nil /* errorChannel */)
+		}, nil, cca.s2sPreserveBlobTags, cca.logVerbosity.ToPipelineLogLevel(), cca.cpkOptions, nil /* errorChannel */, true, queueUnstartedDirs)
 
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func (cca *cookedSyncCmdArgs) initEnumerator(ctx context.Context) (enumerator *s
 		if entityType == common.EEntityType.File() {
 			atomic.AddUint64(&cca.atomicDestinationFilesScanned, 1)
 		}
-	}, nil, cca.s2sPreserveBlobTags, cca.logVerbosity.ToPipelineLogLevel(), cca.cpkOptions, nil /* errorChannel */)
+	}, nil, cca.s2sPreserveBlobTags, cca.logVerbosity.ToPipelineLogLevel(), cca.cpkOptions, nil /* errorChannel */, false, queueUnstartedDirs)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/zc_enumerator.go
+++ b/cmd/zc_enumerator.go
@@ -307,7 +307,7 @@ type enumerationCounterFunc func(entityType common.EntityType)
 func InitResourceTraverser(resource common.ResourceString, location common.Location, ctx *context.Context,
 	credential *common.CredentialInfo, followSymlinks *bool, listOfFilesChannel chan string, recursive, getProperties,
 	includeDirectoryStubs bool, incrementEnumerationCounter enumerationCounterFunc, listOfVersionIds chan string,
-	s2sPreserveBlobTags bool, logLevel pipeline.LogLevel, cpkOptions common.CpkOptions, errorChannel chan ErrorFileInfo) (ResourceTraverser, error) {
+	s2sPreserveBlobTags bool, logLevel pipeline.LogLevel, cpkOptions common.CpkOptions, errorChannel chan ErrorFileInfo, isSource bool, queueUnstartedDirs chan interface{}) (ResourceTraverser, error) {
 	var output ResourceTraverser
 	var p *pipeline.Pipeline
 
@@ -375,7 +375,7 @@ func InitResourceTraverser(resource common.ResourceString, location common.Locat
 			output = newListTraverser(baseResource, location, nil, nil, recursive, toFollow, getProperties,
 				globChan, includeDirectoryStubs, incrementEnumerationCounter, s2sPreserveBlobTags, logLevel, cpkOptions)
 		} else {
-			output = newLocalTraverser(ctx, resource.ValueLocal(), recursive, toFollow, incrementEnumerationCounter, errorChannel)
+			output = newLocalTraverser(ctx, resource.ValueLocal(), recursive, toFollow, incrementEnumerationCounter, errorChannel, isSource, queueUnstartedDirs)
 		}
 	case common.ELocation.Benchmark():
 		ben, err := newBenchmarkTraverser(resource.Value, incrementEnumerationCounter)
@@ -408,7 +408,7 @@ func InitResourceTraverser(resource common.ResourceString, location common.Locat
 		} else if listOfVersionIds != nil {
 			output = newBlobVersionsTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, listOfVersionIds, cpkOptions)
 		} else {
-			output = newBlobTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, s2sPreserveBlobTags, cpkOptions)
+			output = newBlobTraverser(resourceURL, *p, *ctx, recursive, includeDirectoryStubs, incrementEnumerationCounter, s2sPreserveBlobTags, cpkOptions, isSource, queueUnstartedDirs)
 		}
 	case common.ELocation.File():
 		resourceURL, err := resource.FullURL()

--- a/cmd/zc_traverser_blob_account.go
+++ b/cmd/zc_traverser_blob_account.go
@@ -23,8 +23,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/nitin-deamon/azure-storage-azcopy/v10/common"
 	"net/url"
+
+	"github.com/nitin-deamon/azure-storage-azcopy/v10/common"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
@@ -101,7 +102,7 @@ func (t *blobAccountTraverser) Traverse(preprocessor objectMorpher, processor ob
 	for _, v := range cList {
 		containerURL := t.accountURL.NewContainerURL(v).URL()
 		containerTraverser := newBlobTraverser(&containerURL, t.p, t.ctx, true,
-			t.includeDirectoryStubs, t.incrementEnumerationCounter, t.s2sPreserveSourceTags, t.cpkOptions)
+			t.includeDirectoryStubs, t.incrementEnumerationCounter, t.s2sPreserveSourceTags, t.cpkOptions, true, nil)
 
 		preprocessorForThisChild := preprocessor.FollowedBy(newContainerDecorator(v))
 

--- a/cmd/zc_traverser_file.go
+++ b/cmd/zc_traverser_file.go
@@ -23,10 +23,11 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/nitin-deamon/azure-storage-azcopy/v10/common/parallel"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/nitin-deamon/azure-storage-azcopy/v10/common/parallel"
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-file-go/azfile"
@@ -229,7 +230,7 @@ func (t *fileTraverser) Traverse(preprocessor objectMorpher, processor objectPro
 
 	workerContext, cancelWorkers := context.WithCancel(t.ctx)
 
-	cCrawled := parallel.Crawl(workerContext, directoryURL, enumerateOneDir, parallelism)
+	cCrawled := parallel.Crawl(workerContext, directoryURL, enumerateOneDir, parallelism, true, nil)
 
 	cTransformed := parallel.Transform(workerContext, cCrawled, convertToStoredObject, parallelism)
 

--- a/cmd/zc_traverser_list.go
+++ b/cmd/zc_traverser_list.go
@@ -23,8 +23,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-pipeline-go/pipeline"
 	"net/url"
+
+	"github.com/Azure/azure-pipeline-go/pipeline"
 
 	"github.com/nitin-deamon/azure-storage-azcopy/v10/common"
 )
@@ -109,7 +110,7 @@ func newListTraverser(parent common.ResourceString, parentType common.Location, 
 		// Construct a traverser that goes through the child
 		traverser, err := InitResourceTraverser(source, parentType, ctx, credential, &followSymlinks,
 			nil, recursive, getProperties, includeDirectoryStubs, incrementEnumerationCounter,
-			nil, s2sPreserveBlobTags, logLevel, cpkOptions, nil)
+			nil, s2sPreserveBlobTags, logLevel, cpkOptions, nil, false, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/common/parallel/FileSystemCrawler.go
+++ b/common/parallel/FileSystemCrawler.go
@@ -47,13 +47,13 @@ type DirReader interface {
 // It does not follow symlinks.
 // The items in the CrawResult output channel are FileSystemEntry s.
 // For a wrapper that makes this look more like filepath.Walk, see parallel.Walk.
-func CrawlLocalDirectory(ctx context.Context, root string, parallelism int, reader DirReader) <-chan CrawlResult {
+func CrawlLocalDirectory(ctx context.Context, root string, parallelism int, reader DirReader, isSource bool, queueUnstartedDirs chan interface{}) <-chan CrawlResult {
 	return Crawl(ctx,
 		root,
 		func(dir Directory, enqueueDir func(Directory), enqueueOutput func(DirectoryEntry, error)) error {
 			return enumerateOneFileSystemDirectory(dir, enqueueDir, enqueueOutput, reader)
 		},
-		parallelism,
+		parallelism, isSource, queueUnstartedDirs,
 	)
 }
 
@@ -63,7 +63,7 @@ func CrawlLocalDirectory(ctx context.Context, root string, parallelism int, read
 //    (whereas with filepath.Walk it will usually (always?) have a value).
 // 2. If the return value of walkFunc function is not nil, enumeration will always stop, not matter what the type of the error.
 //    (Unlike filepath.WalkFunc, where returning filePath.SkipDir is handled as a special case).
-func Walk(appCtx context.Context, root string, parallelism int, parallelStat bool, walkFn filepath.WalkFunc) {
+func Walk(appCtx context.Context, root string, parallelism int, parallelStat bool, walkFn filepath.WalkFunc, isSource bool, queueUnstartedDirs chan interface{}) {
 	var ctx context.Context
 	var cancel context.CancelFunc
 	signalRootError := func(e error) {
@@ -103,7 +103,7 @@ func Walk(appCtx context.Context, root string, parallelism int, parallelStat boo
 	} else {
 		ctx, cancel = context.WithCancel(context.Background())
 	}
-	ch := CrawlLocalDirectory(ctx, root, remainingParallelism, reader)
+	ch := CrawlLocalDirectory(ctx, root, remainingParallelism, reader, isSource, queueUnstartedDirs)
 	for crawlResult := range ch {
 		entry, err := crawlResult.Item()
 		if err == nil {

--- a/common/parallel/TreeCrawler.go
+++ b/common/parallel/TreeCrawler.go
@@ -35,6 +35,8 @@ type crawler struct {
 	unstartedDirs      []Directory // not a channel, because channels have length limits, and those get in our way
 	dirInProgressCount int64
 	lastAutoShutdown   time.Time
+	queueUnstartedDir  chan interface{}
+	isSource           bool
 }
 
 type Directory interface{}
@@ -54,13 +56,15 @@ type EnumerateOneDirFunc func(dir Directory, enqueueDir func(Directory), enqueue
 
 // Crawl crawls an abstract directory tree, using the supplied enumeration function.  May be use for whatever
 // that function can enumerate (i.e. not necessarily a local file system, just anything tree-structured)
-func Crawl(ctx context.Context, root Directory, worker EnumerateOneDirFunc, parallelism int) <-chan CrawlResult {
+func Crawl(ctx context.Context, root Directory, worker EnumerateOneDirFunc, parallelism int, isSource bool, queueUnstartedDir chan interface{}) <-chan CrawlResult {
 	c := &crawler{
-		unstartedDirs: make([]Directory, 0, 1024),
-		output:        make(chan CrawlResult, 1000),
-		workerBody:    worker,
-		parallelism:   parallelism,
-		cond:          sync.NewCond(&sync.Mutex{}),
+		unstartedDirs:     make([]Directory, 0, 1024),
+		output:            make(chan CrawlResult, 1000),
+		workerBody:        worker,
+		parallelism:       parallelism,
+		cond:              sync.NewCond(&sync.Mutex{}),
+		queueUnstartedDir: queueUnstartedDir,
+		isSource:          isSource,
 	}
 	go c.start(ctx, root)
 	return c.output
@@ -80,8 +84,25 @@ func (c *crawler) start(ctx context.Context, root Directory) {
 	}
 	go heartbeat()
 
-	c.unstartedDirs = append(c.unstartedDirs, root)
+	waitForUnstartedDirs := func() {
+		for unstartedDir := range c.queueUnstartedDir {
+			c.cond.L.Lock()
+			{
+				c.unstartedDirs = append(c.unstartedDirs, unstartedDir)
+				c.cond.Broadcast()
+			}
+			c.cond.L.Unlock()
+		}
+	}
+	if !c.isSource {
+		go waitForUnstartedDirs()
+	} else {
+		c.unstartedDirs = append(c.unstartedDirs, root)
+	}
 	c.runWorkersToCompletion(ctx)
+	if c.isSource {
+		close(c.queueUnstartedDir)
+	}
 	close(c.output)
 	close(done)
 }
@@ -179,10 +200,11 @@ func (c *crawler) processOneDirectory(ctx context.Context, workerIndex int) (boo
 	// finally, update shared state (inside the lock)
 	c.cond.L.Lock()
 	defer c.cond.L.Unlock()
-
-	c.unstartedDirs = append(c.unstartedDirs, foundDirectories...) // do NOT try to wait here if unstartedDirs is getting big. May cause deadlocks, due to all workers waiting and none processing the queue
-	c.dirInProgressCount--                                         // we were doing something, and now we have finished it
-	c.cond.Broadcast()                                             // let other workers know that the state has changed
+	if c.isSource {
+		c.unstartedDirs = append(c.unstartedDirs, foundDirectories...) // do NOT try to wait here if unstartedDirs is getting big. May cause deadlocks, due to all workers waiting and none processing the queue
+	}
+	c.dirInProgressCount-- // we were doing something, and now we have finished it
+	c.cond.Broadcast()     // let other workers know that the state has changed
 
 	// If our queue of unstarted stuff is getting really huge,
 	// reduce our parallelism in the hope of preventing further excessive RAM growth.
@@ -197,6 +219,9 @@ func (c *crawler) processOneDirectory(ctx context.Context, workerIndex int) (boo
 	if shouldShutSelfDown {
 		c.lastAutoShutdown = time.Now()
 		return false, bodyErr
+	}
+	if c.isSource && c.queueUnstartedDir != nil {
+		c.queueUnstartedDir <- toExamine
 	}
 
 	return true, bodyErr // true because, as far as we know, the work is not finished. And err because it was the err (if any) from THIS dir


### PR DESCRIPTION
This PR starts to build sync changes by using a streaming approach.
Things left to do:
* more comments
* need to compare with the relative path instead of base path during target enumeration
* make source and target traversers parallel