### PR TITLE
Fix for the regular copy case.

### DIFF
--- a/common/parallel/TreeCrawler.go
+++ b/common/parallel/TreeCrawler.go
@@ -380,6 +380,8 @@ func (c *crawler) processOneDirectoryWithAutoPacer(ctx context.Context, workerIn
 		}
 
 		c.unstartedDirs = append(c.unstartedDirs, foundDirectories...)
+	} else if !c.isSync {
+		c.unstartedDirs = append(c.unstartedDirs, foundDirectories...)
 	}
 
 	c.dirInProgressCount-- // we were doing something, and now we have finished it


### PR DESCRIPTION
- In processOneDirectoryWithAutoPacer function we are not appending
  dirs for regular case.
This patch fix that issue.